### PR TITLE
fix(core): fix improper route translations on pipe

### DIFF
--- a/packages/@ngx-i18n-router/core/src/i18n-router.service.ts
+++ b/packages/@ngx-i18n-router/core/src/i18n-router.service.ts
@@ -63,7 +63,10 @@ export class I18NRouterService {
   getTranslation(key: string): string {
     key = key.replace(/-/, '_');
 
-    return _.get(this.translations, `${this.languageCode}.${key.toUpperCase()}`, undefined);
+    if (!this.translations[this.languageCode][key.toUpperCase()])
+      return undefined;
+
+    return this.translations[this.languageCode][key.toUpperCase()];
   }
 
   translateRoutes(routes: Routes, moduleKey = ''): Routes {


### PR DESCRIPTION
** PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/fulls1z3/ngx-i18n-router/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

** PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

** What is the current behavior?
As @Pipweak said:

The problem is using this kind of config structure into  config.json file: 
```
  "routes": {
    "en": {
      "ROOT.VISIT": "visit"
   },
    "fr": {
      "ROOT.VISIT": "visiter",
   }
```
path is an array(3) like this : 
0:"fr"
1:"ROOT"
2:"VISIT"

The translation will never be found because our key "ROOT.VISIT" is splited.

Issue Number: #10

The translation is found.

** Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

** Other information
